### PR TITLE
Fix phi-train notebook errors

### DIFF
--- a/phi-train-fixed.ipynb
+++ b/phi-train-fixed.ipynb
@@ -1,0 +1,265 @@
+{
+  "metadata": {
+    "kernelspec": {
+      "language": "python",
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "pygments_lexer": "ipython3",
+      "nbconvert_exporter": "python",
+      "version": "3.6.4",
+      "file_extension": ".py",
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "name": "python",
+      "mimetype": "text/x-python"
+    },
+    "kaggle": {
+      "accelerator": "gpu",
+      "dataSources": [],
+      "dockerImageVersionId": 31011,
+      "isInternetEnabled": true,
+      "language": "python",
+      "sourceType": "notebook",
+      "isGpuEnabled": true
+    }
+  },
+  "nbformat_minor": 4,
+  "nbformat": 4,
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Training Phi-3-mini-128k-instruct to Learn Swift Programming Language\n",
+        "\n",
+        "This notebook trains Microsoft's Phi-3-mini-128k-instruct model to understand and work with Swift code using a dataset of real Swift files."
+      ],
+      "metadata": {
+        "id": "fae3237b"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Install required packages\n",
+        "!pip install transformers datasets evaluate torch scikit-learn tqdm dropbox requests accelerate peft bitsandbytes"
+      ],
+      "metadata": {
+        "id": "b83febc7"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import os\n",
+        "import torch\n",
+        "import numpy as np\n",
+        "from datasets import load_dataset\n",
+        "from transformers import (\n",
+        "    AutoModelForCausalLM,\n",
+        "    AutoTokenizer,\n",
+        "    TrainingArguments,\n",
+        "    Trainer,\n",
+        "    DataCollatorForLanguageModeling\n",
+        ")\n",
+        "from peft import LoraConfig, get_peft_model, prepare_model_for_kbit_training\n",
+        "from tqdm import tqdm"
+      ],
+      "metadata": {},
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Load the model and tokenizer\n",
+        "model_name = \"microsoft/phi-3-mini-128k-instruct\"\n",
+        "tokenizer = AutoTokenizer.from_pretrained(model_name)\n",
+        "tokenizer.pad_token = tokenizer.eos_token\n",
+        "\n",
+        "# Load model with quantization for efficiency\n",
+        "model = AutoModelForCausalLM.from_pretrained(\n",
+        "    model_name,\n",
+        "    torch_dtype=torch.bfloat16,\n",
+        "    device_map=\"auto\",\n",
+        "    load_in_8bit=True\n",
+        ")"
+      ],
+      "metadata": {},
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Prepare the model for training\n",
+        "model = prepare_model_for_kbit_training(model)\n",
+        "\n",
+        "# Configure LoRA\n",
+        "lora_config = LoraConfig(\n",
+        "    r=16,\n",
+        "    lora_alpha=32,\n",
+        "    lora_dropout=0.05,\n",
+        "    bias=\"none\",\n",
+        "    task_type=\"CAUSAL_LM\",\n",
+        "    target_modules=[\"q_proj\", \"k_proj\", \"v_proj\", \"o_proj\"]\n",
+        ")\n",
+        "\n",
+        "# Apply LoRA to the model\n",
+        "model = get_peft_model(model, lora_config)"
+      ],
+      "metadata": {},
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Load and prepare the Swift code dataset\n",
+        "def load_swift_files(directory=\"code_by_language/Swift\", max_files=1000):\n",
+        "    files = []\n",
+        "    for filename in os.listdir(directory)[:max_files]:\n",
+        "        if filename.endswith(\".swift\"):\n",
+        "            file_path = os.path.join(directory, filename)\n",
+        "            try:\n",
+        "                with open(file_path, 'r', encoding='utf-8') as f:\n",
+        "                    content = f.read()\n",
+        "                    if content.strip():  # Skip empty files\n",
+        "                        files.append({\"text\": content})\n",
+        "            except Exception as e:\n",
+        "                print(f\"Error reading {file_path}: {e}\")\n",
+        "    return files\n",
+        "\n",
+        "# Load Swift files\n",
+        "swift_files = load_swift_files()\n",
+        "print(f\"Loaded {len(swift_files)} Swift files\")\n",
+        "\n",
+        "# Create a dataset\n",
+        "from datasets import Dataset\n",
+        "dataset = Dataset.from_list(swift_files)\n",
+        "\n",
+        "# Split the dataset\n",
+        "dataset = dataset.train_test_split(test_size=0.1)\n",
+        "train_dataset = dataset[\"train\"]\n",
+        "eval_dataset = dataset[\"test\"]\n",
+        "\n",
+        "print(f\"Training set: {len(train_dataset)} examples\")\n",
+        "print(f\"Evaluation set: {len(eval_dataset)} examples\")"
+      ],
+      "metadata": {},
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Tokenize the dataset\n",
+        "def tokenize_function(examples):\n",
+        "    return tokenizer(examples[\"text\"], truncation=True, max_length=2048)\n",
+        "\n",
+        "tokenized_train = train_dataset.map(tokenize_function, batched=True, remove_columns=[\"text\"])\n",
+        "tokenized_eval = eval_dataset.map(tokenize_function, batched=True, remove_columns=[\"text\"])"
+      ],
+      "metadata": {},
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Configure the data collator with padding and truncation\n",
+        "data_collator = DataCollatorForLanguageModeling(\n",
+        "    tokenizer=tokenizer,\n",
+        "    mlm=False,\n",
+        "    padding=True,\n",
+        "    truncation=True\n",
+        ")"
+      ],
+      "metadata": {},
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Configure training arguments\n",
+        "training_args = TrainingArguments(\n",
+        "    output_dir=\"./phi-3-swift-finetuned\",\n",
+        "    evaluation_strategy=\"epoch\",\n",
+        "    learning_rate=2e-4,\n",
+        "    weight_decay=0.01,\n",
+        "    num_train_epochs=3,\n",
+        "    per_device_train_batch_size=4,\n",
+        "    per_device_eval_batch_size=4,\n",
+        "    gradient_accumulation_steps=4,\n",
+        "    save_strategy=\"epoch\",\n",
+        "    load_best_model_at_end=True,\n",
+        "    push_to_hub=False,\n",
+        "    fp16=True\n",
+        ")\n",
+        "\n",
+        "# Initialize the Trainer\n",
+        "trainer = Trainer(\n",
+        "    model=model,\n",
+        "    args=training_args,\n",
+        "    train_dataset=tokenized_train,\n",
+        "    eval_dataset=tokenized_eval,\n",
+        "    data_collator=data_collator,\n",
+        "    label_names=[],  # Empty list for PeftModelForCausalLM\n",
+        ")"
+      ],
+      "metadata": {},
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Train the model\n",
+        "trainer.train()"
+      ],
+      "metadata": {},
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Save the model\n",
+        "model.save_pretrained(\"./phi-3-swift-finetuned-final\")\n",
+        "tokenizer.save_pretrained(\"./phi-3-swift-finetuned-final\")"
+      ],
+      "metadata": {},
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Test the model with a Swift code prompt\n",
+        "test_prompt = \"\"\"\n",
+        "Write a Swift function that sorts an array of integers using the quicksort algorithm.\n",
+        "\"\"\"\n",
+        "\n",
+        "inputs = tokenizer(test_prompt, return_tensors=\"pt\").to(\"cuda\")\n",
+        "outputs = model.generate(\n",
+        "    **inputs,\n",
+        "    max_new_tokens=500,\n",
+        "    temperature=0.7,\n",
+        "    top_p=0.9,\n",
+        "    do_sample=True\n",
+        ")\n",
+        "response = tokenizer.decode(outputs[0], skip_special_tokens=True)\n",
+        "print(response)"
+      ],
+      "metadata": {},
+      "execution_count": null,
+      "outputs": []
+    }
+  ]
+}


### PR DESCRIPTION
This PR fixes the errors in the phi-train notebook:

1. Added `padding=True` and `truncation=True` to the DataCollator to fix the "Unable to create tensor" error
2. Added `label_names=[]` to the Trainer configuration to fix the PeftModelForCausalLM label_names warning

The original notebook had a nested structure that was difficult to modify, so I created a new clean notebook with all the necessary fixes.